### PR TITLE
Fixed jackson dependencies version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <config.version>1.3.1</config.version>
-        <jackson.version>2.13.4.1</jackson.version>
+        <jackson.version>2.13.5</jackson.version>
 
         <simplification.version>5.0.0</simplification.version>
 


### PR DESCRIPTION
The version bump for jackson-databind to 2.13.4.1 fails.

This happens because it was made via [jackson.version](https://github.com/Lambda-3/DiscourseSimplification/blob/master/pom.xml#L44), but this variable is used also for jackson-annotations, which has [no such version](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations).

Bumping to version 2.13.5 appears to resolve the problem. All tests pass.